### PR TITLE
Integrate weavelet process with Lightning training

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,12 +1,13 @@
-# Plan for Updating TODO and Suggesting Additional Features
+# Plan for Weavelet Integration
 
 ## Goal
-Enhance TODO.md with more detailed tasks for runtime configuration features beyond learning rate and incorporate the PyTorch Lightning integration.
+Integrate a weavelet process into the Lightning training example so it can receive configuration updates from the weaver. The weavelet should run in a separate process and communicate optimizer type changes to the training process. Callback hooks will check the weavelet queue and update the optimizer when required.
 
 ## Steps
-- Review existing TODO.md and controller/runtime code for context.
-- Identify new adjustable parameters that could be controlled via JetStream messages.
-- Update TODO.md with bullet points describing the new runtime control features, the Lightning integration via callback or context manager, and clearer instructions for each item.
-- Keep the style of bullet points (no numbering) per AGENTs instructions.
-- Commit the plan and the updated TODO.md.
-
+- Create a new module `torchLoom/weavelet.py` with a simple async loop that connects to NATS and listens for config messages. When an `optimizer_type` value is found it is put on a multiprocessing queue.
+- Update `train.py`:
+  - Spawn the weavelet process before starting training.
+  - Extend `LightningTransformer` with dynamic optimizer creation and an `update_optimizer` method.
+  - Add `WeaveletCallback` that checks the queue at the start of each epoch and applies optimizer updates.
+- Add unit tests verifying that `update_optimizer` and the callback correctly change the optimizer based on queued values.
+- Run `pytest` to ensure the repository remains stable.

--- a/tests/test_weavelet_callback.py
+++ b/tests/test_weavelet_callback.py
@@ -1,0 +1,26 @@
+import queue
+import torch
+from train import LightningTransformer, WeaveletCallback
+
+class DummyProcess:
+    def __init__(self):
+        self.alive = True
+    def is_alive(self):
+        return self.alive
+
+def test_callback_updates_optimizer():
+    q = queue.Queue()
+    proc = DummyProcess()
+    model = LightningTransformer(vocab_size=10)
+    # Simulate trainer with an optimizer list
+    class DummyTrainer:
+        def __init__(self, opt):
+            self.optimizers = [opt]
+    trainer = DummyTrainer(model.configure_optimizers())
+    model.trainer = trainer
+
+    cb = WeaveletCallback(q, proc)
+    q.put("Adam")
+    cb.on_train_epoch_start(trainer, model)
+    assert isinstance(trainer.optimizers[0], torch.optim.Adam)
+

--- a/torchLoom/weavelet.py
+++ b/torchLoom/weavelet.py
@@ -1,0 +1,38 @@
+import asyncio
+import multiprocessing as mp
+
+import nats
+from nats.js.api import StreamConfig
+
+from torchLoom.constants import torchLoomConstants
+from torchLoom.torchLoom_pb2 import EventEnvelope
+
+
+async def _listen_for_config(queue: mp.Queue, addr: str) -> None:
+    nc = await nats.connect(addr)
+    js = nc.jetstream()
+    # ensure stream exists for config updates
+    await js.add_stream(StreamConfig(name="WEAVELET_STREAM", subjects=[torchLoomConstants.subjects.CONFIG_INFO]))
+    sub = await js.pull_subscribe(
+        torchLoomConstants.subjects.CONFIG_INFO,
+        durable="weavelet",
+        stream="WEAVELET_STREAM",
+    )
+    while True:
+        try:
+            msgs = await sub.fetch(1, timeout=1)
+        except Exception:
+            continue
+        for msg in msgs:
+            env = EventEnvelope()
+            env.ParseFromString(msg.data)
+            if env.HasField("config_info"):
+                params = env.config_info.config_params
+                if "optimizer_type" in params:
+                    queue.put(params["optimizer_type"])
+            await msg.ack()
+
+
+def weavelet_process(queue: mp.Queue, addr: str = torchLoomConstants.DEFAULT_ADDR) -> None:
+    asyncio.run(_listen_for_config(queue, addr))
+

--- a/train.py
+++ b/train.py
@@ -1,8 +1,12 @@
 import lightning as L
 import torch
 import time
+import multiprocessing as mp
 from lightning.pytorch.demos import Transformer
+from lightning.pytorch.callbacks import Callback
 from torch.utils.data import DataLoader, Dataset
+
+from torchLoom.weavelet import weavelet_process
 
 class RandomTextDataset(Dataset):
     def __init__(self, num_samples=1000, seq_len=32, vocab_size=1000):
@@ -20,6 +24,9 @@ class LightningTransformer(L.LightningModule):
     def __init__(self, vocab_size):
         super().__init__()
         self.model = Transformer(vocab_size=vocab_size)
+        self.optimizer_type = "SGD"
+        self.lr = 0.1
+        self.optimizer = None
 
     def forward(self, inputs, target):
         return self.model(inputs, target)
@@ -31,12 +38,52 @@ class LightningTransformer(L.LightningModule):
         time.sleep(1)
         return loss
 
+    def _create_optimizer(self):
+        if self.optimizer_type == "Adam":
+            return torch.optim.Adam(self.model.parameters(), lr=self.lr)
+        return torch.optim.SGD(self.model.parameters(), lr=self.lr)
+
     def configure_optimizers(self):
-        return torch.optim.SGD(self.model.parameters(), lr=0.1)
+        self.optimizer = self._create_optimizer()
+        return self.optimizer
+
+    def update_optimizer(self, optimizer_type: str) -> None:
+        if optimizer_type == self.optimizer_type:
+            return
+        self.optimizer_type = optimizer_type
+        new_opt = self._create_optimizer()
+        if self.trainer is not None:
+            self.trainer.optimizers = [new_opt]
+        self.optimizer = new_opt
     
 dataset = RandomTextDataset(vocab_size=1000)
 dataloader = DataLoader(dataset, batch_size=32)
+class WeaveletCallback(Callback):
+    def __init__(self, queue: mp.Queue, process: mp.Process):
+        self.queue = queue
+        self.process = process
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        while True:
+            try:
+                opt_type = self.queue.get_nowait()
+            except Exception:
+                break
+            pl_module.update_optimizer(opt_type)
+        if not self.process.is_alive():
+            raise RuntimeError("Weavelet process terminated")
+
+
 model = LightningTransformer(vocab_size=dataset.vocab_size)
 
-trainer = L.Trainer(fast_dev_run=100)
-trainer.fit(model=model, train_dataloaders=dataloader)
+if __name__ == "__main__":
+    q = mp.Queue()
+    proc = mp.Process(target=weavelet_process, args=(q,))
+    proc.start()
+
+    callback = WeaveletCallback(q, proc)
+    trainer = L.Trainer(fast_dev_run=100, callbacks=[callback])
+    trainer.fit(model=model, train_dataloaders=dataloader)
+
+    proc.terminate()
+    proc.join()


### PR DESCRIPTION
## Summary
- update plan with steps for weavelet integration
- add a weavelet process to listen for config updates via JetStream
- modify `train.py` to spawn the weavelet, add callback, and update optimizers dynamically
- add unit test for the callback behaviour

## Testing
- `pytest tests/test_weavelet_callback.py::test_callback_updates_optimizer -q`
- `pytest -q`