### PR TITLE
Add repository overview to agent guide

### DIFF
--- a/AGENTs.md
+++ b/AGENTs.md
@@ -37,3 +37,18 @@
 lintrunner init
 lintrunner -a
 ```
+
+## Repository Information
+* The main package lives in `torchLoom/` and includes modules like `weaver.py`,
+  `monitor_cli.py`, and `weavelet.py`.
+* The example training script is `examples/pytorch/mnist.py`.
+* Start the NATS server with `./nats/nats-server -c ./nats/nats.conf` and run
+  the weaver using `python -m torchLoom.weaver`.
+* The interactive CLI can be launched with `python -m torchLoom.monitor_cli`.
+* To test training end to end, run the training script after the server and
+  weaver are running.
+* Create the Python environment with `conda env create -f environment.yaml` and
+  activate it before running any commands.
+* All tests are under the `tests/` directory and should be run with `pytest`.
+* Additional documentation is in the `docs/` folder with design notes in
+  `docs/design`.

--- a/plan.md
+++ b/plan.md
@@ -34,3 +34,16 @@ opt_type: str = self.queue.get_nowait()
 - Code imports and runs without runtime errors
 
 This fix ensures that Pyre understands the expected type while maintaining all existing functionality.
+
+## Repo Documentation Task
+
+### Goal
+Add repository-specific guidance to AGENTs.md for easier onboarding and investigation.
+
+### Steps
+- Review repo layout including packages, docs, and tests.
+- Summarize environment setup from environment.yaml.
+- Document how to start the NATS server, run the weaver, the CLI and the example training script.
+- Note where tests live and how to run them with pytest.
+- Add this summary to a new "Repository Information" section in AGENTs.md.
+


### PR DESCRIPTION
## Summary
- document repository layout in AGENTs.md for easier onboarding
- note environment setup, how to start NATS server, run CLI and tests
- capture tasks in plan.md

## Testing
- `lintrunner init` *(fails: Could not install black)*
- `lintrunner -a`
- `pytest -q`